### PR TITLE
Retain whitespace between project description & button

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,11 +97,10 @@ Danke an Benni für die Umsetzung.
 								</footer> -->
 							</section>
 
-
 						<!-- Second Section -->
 						<section id="second" class="main special">
 								<header class="major">
-	</br>
+								<br />
 								<h2><img src="./images/Logo_Open_Data_Barcamp.png" alt="Logo des BarCamp Potsdam.io"></h2>
 									<p>Alles rund um Open Data und Open Knowledge <br />
 	in Brandenburg und Potsdam
@@ -148,10 +147,9 @@ Danke an Benni für die Umsetzung.
 						<!-- Get Started -->
 							<section id="cta" class="main special">
 								<header class="major">
-
-	</br>
+								<br />
 								<h2>Mitmachen</h2>
-									<p>Wir treffen uns jeden 2. Dienstag in der <a href="https://machbar-potsdam.de/" target="_blank">machBar</a> im Freiland Potsdam.</br>
+									<p>Wir treffen uns jeden 2. Dienstag in der <a href="https://machbar-potsdam.de/" target="_blank">machBar</a> im Freiland Potsdam.<br />
 Kommt vorbei und bringt euch ein. Details zum aktuellen Termin gibt es auf <a href="http://www.meetup.com/de-DE/OK-Lab-Potsdam/">Meetup</a>.</p>
 								</header>
 								<footer class="major">

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
 										<header class="major">
 											<h2>OK Lab Potsdam</h2>
 										</header>
-										<p>Wir Treffen uns jeden 2. Dienstag um gemeinsam an offenen Daten zu arbeiten.
+										<p>Wir treffen uns jeden 2. Dienstag, um gemeinsam an offenen Daten zu arbeiten.
 										Jeder kann mitmachen!
 										Wir glauben, dass mit den richtigen Informationen Probleme schneller gelöst und bessere Entscheidungen getroffen werden können.</p>
 										<ul class="actions">
@@ -151,8 +151,8 @@ Danke an Benni für die Umsetzung.
 
 	</br>
 								<h2>Mitmachen</h2>
-									<p>Wir Treffen uns jeden 2. Dienstag in der <a href="https://machbar-potsdam.de/" target="_blank">machBar</a> im Freiland Potsdam</br>
-Kommt vorbei und bring euch ein. Details zum aktuellen Termin gibt es auf <a href="http://www.meetup.com/de-DE/OK-Lab-Potsdam/">Meetup</a>.</p>
+									<p>Wir treffen uns jeden 2. Dienstag in der <a href="https://machbar-potsdam.de/" target="_blank">machBar</a> im Freiland Potsdam.</br>
+Kommt vorbei und bringt euch ein. Details zum aktuellen Termin gibt es auf <a href="http://www.meetup.com/de-DE/OK-Lab-Potsdam/">Meetup</a>.</p>
 								</header>
 								<footer class="major">
 									<ul class="actions">

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 	html5up.net | @ajlkn
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
-<html>
+<html lang="de">
 	<head>
 		<title>OK Lab Potsdam</title>
 		<meta charset="utf-8" />
@@ -23,7 +23,7 @@
 					<header id="header" class="alt">
 						<span class="logo"><img src="images/logo.svg" alt="" /></span>
 						<h1>OK Lab Potsdam</h1>
-						<p>Der Open Data Treff						</p>
+						<p>Der Open Data Treff</p>
 					</header>
 
 				<!-- Nav -->
@@ -66,30 +66,39 @@
 									<li>
 										<span class="icon major style1 fa-calculator"></span>
 										<h3>Kitarechner</h3>
-										<p>Mit dem Kitarechner kann jeder schnell sehen wieviel Kitagebühren er pro Kind bei einer Hort-, Kita-, oder Krippenbetreuung bezahlen muss. Die Tabelle der Stadt wurde dafür ansprechend aufbereitet.
-Danke an Benni für die Umsetzung.
-</p>
-
-									<a href="http://kitarechner.oklab-potsdam.de" class="button alt" target="_blank">Kitarechner</a>
+										<p>
+											Mit dem Kitarechner kann jeder schnell sehen wieviel Kitagebühren er pro Kind bei einer Hort-, Kita-, oder Krippenbetreuung bezahlen muss. Die Tabelle der Stadt wurde dafür ansprechend aufbereitet.
+											Danke an Benni für die Umsetzung.
+										</p>
+										<p>
+											<a href="http://kitarechner.oklab-potsdam.de" class="button alt" target="_blank">Kitarechner</a>
+										</p>
 									</li>
 
-
-								<li>
+									<li>
 										<span class="icon major style5 fa-train"></span>
 										<h3>BrandenGo</h3>
-										<p>Was fährt an öffentlichem Nahverkehr in meiner Nähe? Nach dem Vorbild von <a href="https://magdego.de/">MagdeGo</a>. Derzeit noch in der Prototyphase.
-										</br>  Danke an Johannes für die Umsetzung.
+										<p>
+											Was fährt an öffentlichem Nahverkehr in meiner Nähe? Nach dem Vorbild von <a href="https://magdego.de/">MagdeGo</a>. Derzeit noch in der Prototyphase.
+											Danke an Johannes für die Umsetzung.
+										</p>
+										<p>
+											<a href="https://brandeng.cassiopeia.uberspace.de/" class="button alt" target="_blank">BrandenGo</a>
+										</p>
+									</li>
 
-<a href="https://brandeng.cassiopeia.uberspace.de/" class="button alt" target="_blank">BrandenGo</a>	</li>
-
-<li>
-
+									<li>
 										<span class="icon major style3 fa-tint"></span>
 										<h3>Potsdamer Leitungswasser</h3>
-										<p>Leitungswasser gehört zu den am strengsten kontrollierten Lebensmitteln in Deutschland. Welche Mineralien und Stoffe es enthält wird von den Wasserwerken regelmäßig veröffentlicht. Im Kontext mit weiteren Informationen stellen wir die Informationen des Potsdamer Trinkwassers bereit. Danke an das OpendataLab in Heilbronn für die Vorlage und Florian für die Umsetzung.</p>
-<ul class="actions">
-<a href="http://trinkwasser.oklab-potsdam.de" class="button alt" target="_blank">Trinkwasserviz</a>	</li>
-							</ul>
+										<p>
+											Leitungswasser gehört zu den am strengsten kontrollierten Lebensmitteln in Deutschland. Welche Mineralien und Stoffe es enthält wird von den Wasserwerken regelmäßig veröffentlicht. Im Kontext mit weiteren Informationen stellen wir die Informationen des Potsdamer Trinkwassers bereit.
+											Danke an das OpendataLab in Heilbronn für die Vorlage und Florian für die Umsetzung.
+										</p>
+										<p>
+											<a href="http://trinkwasser.oklab-potsdam.de" class="button alt" target="_blank">Trinkwasserviz</a>
+										</p>
+									</li>
+								</ul>
 								<!-- <footer class="major">
 									<ul class="actions">
 										<li><a href="generic.html" class="button">Learn More</a></li>
@@ -114,7 +123,6 @@ Danke an Benni für die Umsetzung.
 								<p class="content">
 								Am 12. November 2016 fand das erste Open Data BarCamp im Potsdamer freiLand statt. Unter dem Titel potsdam.io haben wir Praktiker aus Verwaltung, Firmen, Forschung und Zivilgesellschaft zusammengebracht. Diskutiert wurde wie Brandenburg digitaler und offener wird. Unterstützt wurden wir dabei von der Stadt Potsdam und weiteren Sponsoren. Die Idee ist das BarCamp jährlich stattfinden zu lassen.</p>
 
-								<p></p>
 								<ul class="statistics">
 									<li class="style1">
 										<span class="icon fa-calendar-check-o"></span>
@@ -159,7 +167,6 @@ Kommt vorbei und bringt euch ein. Details zum aktuellen Termin gibt es auf <a hr
 									</ul>
 								</footer>
 							</section>
-
 					</div>
 
 				<!-- Footer -->


### PR DESCRIPTION
#### Fixes missing whitespace between project description and “BrandenGo” button

##### Before

![bildschirmfoto 2017-10-30 um 13 15 14](https://user-images.githubusercontent.com/34942/32170534-2d9b34b4-bd75-11e7-92f1-c3925ae124de.png)

##### After

![bildschirmfoto 2017-10-30 um 13 25 06](https://user-images.githubusercontent.com/34942/32170674-cf62ec24-bd75-11e7-91db-daa8a21c8079.png)

